### PR TITLE
fix: correct DELETE response code to 204 in test feature file

### DIFF
--- a/code/Test_definitions/application-profiles.feature
+++ b/code/Test_definitions/application-profiles.feature
@@ -46,7 +46,7 @@ Feature: CAMARA Application Profiles API, vwip - Operations for Application Prof
   Scenario: Delete an application profile successfully
     Given the path parameter "applicationProfileId" is set to the identifier of an existing application profile
     When the request "deleteApplicationProfile" is sent
-    Then the response code is 200
+    Then the response code is 204
     And the response header "x-correlator" has same value as the request header "x-correlator"
 
 ############### Error response scenarios ###########################


### PR DESCRIPTION
## Summary

- Fixes `deleteApplicationProfile` success scenario: expected response code `200` → `204`

The API specification defines a `204 No Content` response for the DELETE operation. The feature file was incorrectly asserting `200`.

Fixes #34

## Test plan

- [ ] Verify `deleteApplicationProfile` returns `204` and the test scenario passes