### PR TITLE
fix: added missing x-correlator headers to 200 / 204 responses

### DIFF
--- a/code/API_definitions/application-profiles.yaml
+++ b/code/API_definitions/application-profiles.yaml
@@ -52,7 +52,7 @@ info:
     <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
 externalDocs:
-  description: Project documentation at CAMARA
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/ApplicationProfiles
 servers:
   - url: "{apiRoot}/application-profiles/vwip"

--- a/code/API_definitions/application-profiles.yaml
+++ b/code/API_definitions/application-profiles.yaml
@@ -52,7 +52,7 @@ info:
     <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
 externalDocs:
-  description: Project documentation at Camara
+  description: Project documentation at CAMARA
   url: https://github.com/camaraproject/ApplicationProfiles
 servers:
   - url: "{apiRoot}/application-profiles/vwip"
@@ -144,7 +144,10 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: 200 OK
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"          
           content:
             application/json:
               schema:
@@ -184,6 +187,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -223,6 +229,9 @@ paths:
       responses:
         "204":
           description: Application profile has been deleted successfully.
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/application-profiles.yaml
+++ b/code/API_definitions/application-profiles.yaml
@@ -147,7 +147,7 @@ paths:
           description: 200 OK
           headers:
             x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"          
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug



#### What this PR does / why we need it:
Adds the missing x-correlator header to 200 and 204 reponses



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #37




